### PR TITLE
39 change sqlpgq properties in client data to extension client data

### DIFF
--- a/extension/sqlpgq/include/sqlpgq-extension.hpp
+++ b/extension/sqlpgq/include/sqlpgq-extension.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "sqlpgq_common.hpp"
 
 namespace duckdb {
 

--- a/extension/sqlpgq/include/sqlpgq_common.hpp
+++ b/extension/sqlpgq/include/sqlpgq_common.hpp
@@ -54,7 +54,7 @@ public:
 
     }
 
-protected:
+public:
     //! Property graphs that are registered
     std::unordered_map<string, unique_ptr<CreateInfo>> registered_property_graphs;
 

--- a/extension/sqlpgq/include/sqlpgq_common.hpp
+++ b/extension/sqlpgq/include/sqlpgq_common.hpp
@@ -28,17 +28,6 @@ public:
         return reinterpret_cast<CreatePropertyGraphInfo*>(pg_table_entry->second.get());
     }
 
-    void InsertPropertyGraph(const string &pg_name, unique_ptr<CreateInfo> pg) {
-        registered_property_graphs[pg_name] = std::move(pg);
-    }
-
-    void InsertCSR(int32_t id, unique_ptr<CSR> csr) {
-        csr_list[id] = std::move(csr);
-    }
-    void EraseCSR(int32_t id) {
-        csr_list.erase(id);
-    }
-
     CSR* GetCSR(int32_t id) {
         auto csr_entry = csr_list.find(id);
         if (csr_entry == csr_list.end()) {
@@ -50,8 +39,7 @@ public:
 
     void QueryEnd() override {
         // Check if it contains a path query
-
-
+        csr_list.clear();
     }
 
 public:

--- a/extension/sqlpgq/include/sqlpgq_common.hpp
+++ b/extension/sqlpgq/include/sqlpgq_common.hpp
@@ -14,6 +14,38 @@
 
 namespace duckdb {
 
+class SQLPGQContext : public ClientContextState {
+public:
+    explicit SQLPGQContext() {
+
+    }
+
+    void InsertNewPropertyGraph() {
+
+    }
+
+    void InsertNewCSR(int32_t id, unique_ptr<CSR> csr) {
+        csr_list[id] = std::move(csr);
+    }
+    void EraseCSR(int32_t id) {
+        csr_list.erase(id);
+    }
+
+    void QueryEnd() override {
+        // Check if it contains a path query
+
+
+    }
+
+protected:
+    //! Property graphs that are registered
+    std::unordered_map<string, unique_ptr<CreateInfo>> registered_property_graphs;
+
+    //! Used to build the CSR data structures required for path-finding queries
+    std::unordered_map<int32_t, unique_ptr<CSR>> csr_list;
+    std::mutex csr_lock;
+};
+
 struct CSRFunctionData : public FunctionData {
 public:
 	CSRFunctionData(ClientContext &context, int32_t id, LogicalType weight_type);
@@ -56,5 +88,8 @@ struct CheapestPathLengthFunctionData : public FunctionData {
 	unique_ptr<FunctionData> Copy() const override;
 	bool Equals(const FunctionData &other_p) const override;
 };
+
+
+
 
 } // namespace duckdb

--- a/extension/sqlpgq/include/sqlpgq_common.hpp
+++ b/extension/sqlpgq/include/sqlpgq_common.hpp
@@ -38,7 +38,6 @@ public:
 
 
     void QueryEnd() override {
-        // Check if it contains a path query
         csr_list.clear();
     }
 
@@ -49,6 +48,8 @@ public:
     //! Used to build the CSR data structures required for path-finding queries
     std::unordered_map<int32_t, unique_ptr<CSR>> csr_list;
     std::mutex csr_lock;
+    std::unordered_set<int32_t> csr_to_delete;
+
 };
 
 struct CSRFunctionData : public FunctionData {

--- a/extension/sqlpgq/include/sqlpgq_common.hpp
+++ b/extension/sqlpgq/include/sqlpgq_common.hpp
@@ -36,9 +36,10 @@ public:
         return csr_entry->second.get();
     }
 
-
     void QueryEnd() override {
-        csr_list.clear();
+        for (const auto &csr_id : csr_to_delete) {
+            csr_list.erase(csr_id);
+        }
     }
 
 public:

--- a/extension/sqlpgq/include/sqlpgq_common.hpp
+++ b/extension/sqlpgq/include/sqlpgq_common.hpp
@@ -32,12 +32,21 @@ public:
         registered_property_graphs[pg_name] = std::move(pg);
     }
 
-    void InsertNewCSR(int32_t id, unique_ptr<CSR> csr) {
+    void InsertCSR(int32_t id, unique_ptr<CSR> csr) {
         csr_list[id] = std::move(csr);
     }
     void EraseCSR(int32_t id) {
         csr_list.erase(id);
     }
+
+    CSR* GetCSR(int32_t id) {
+        auto csr_entry = csr_list.find(id);
+        if (csr_entry == csr_list.end()) {
+            throw InternalException("CSR not found with ID %s", id);
+        }
+        return csr_entry->second.get();
+    }
+
 
     void QueryEnd() override {
         // Check if it contains a path query

--- a/extension/sqlpgq/include/sqlpgq_common.hpp
+++ b/extension/sqlpgq/include/sqlpgq_common.hpp
@@ -20,8 +20,16 @@ public:
 
     }
 
-    void InsertNewPropertyGraph() {
+    CreatePropertyGraphInfo* GetPropertyGraph(const string &pg_name) {
+        auto pg_table_entry = registered_property_graphs.find(pg_name);
+        if (pg_table_entry == registered_property_graphs.end()) {
+            throw BinderException("Property graph %s does not exist", pg_name);
+        }
+        return reinterpret_cast<CreatePropertyGraphInfo*>(pg_table_entry->second.get());
+    }
 
+    void InsertPropertyGraph(const string &pg_name, unique_ptr<CreateInfo> pg) {
+        registered_property_graphs[pg_name] = std::move(pg);
     }
 
     void InsertNewCSR(int32_t id, unique_ptr<CSR> csr) {

--- a/extension/sqlpgq/sqlpgq-extension.cpp
+++ b/extension/sqlpgq/sqlpgq-extension.cpp
@@ -15,7 +15,7 @@ void SQLPGQExtension::Load(DuckDB &db) {
 	for (auto &fun : SQLPGQFunctions::GetFunctions()) {
 		catalog.CreateFunction(*con.context, &fun);
 	}
-
+    con.context->registered_state["sqlpgq"] = make_unique<SQLPGQContext>();
 	con.Commit();
 }
 

--- a/extension/sqlpgq/sqlpgq-extension.cpp
+++ b/extension/sqlpgq/sqlpgq-extension.cpp
@@ -15,8 +15,7 @@ void SQLPGQExtension::Load(DuckDB &db) {
 	for (auto &fun : SQLPGQFunctions::GetFunctions()) {
 		catalog.CreateFunction(*con.context, &fun);
 	}
-    con.context->registered_state["sqlpgq"] = make_unique<SQLPGQContext>();
-	con.Commit();
+    con.Commit();
 }
 
 std::string SQLPGQExtension::Name() {

--- a/extension/sqlpgq/sqlpgq_common.cpp
+++ b/extension/sqlpgq/sqlpgq_common.cpp
@@ -89,20 +89,21 @@ CheapestPathLengthFunctionData::CheapestPathLengthBind(ClientContext &context, S
 		throw InvalidInputException("Id must be constant.");
 	}
 
+    auto sqlpgq_state_entry = context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
+
 	int32_t csr_id = ExpressionExecutor::EvaluateScalar(context, *arguments[0]).GetValue<int32_t>();
-	if ((uint64_t)csr_id + 1 > context.client_data->csr_list.size()) {
-		throw ConstraintException("Invalid ID");
-	}
-	auto csr_entry = context.client_data->csr_list.find((uint64_t)csr_id);
-	if (csr_entry == context.client_data->csr_list.end()) {
+    CSR* csr = sqlpgq_state->GetCSR(csr_id);
+
+	if (!(csr->initialized_v && csr->initialized_e && csr->initialized_w)) {
 		throw ConstraintException("Need to initialize CSR before doing cheapest path");
 	}
 
-	if (!(csr_entry->second->initialized_v && csr_entry->second->initialized_e && csr_entry->second->initialized_w)) {
-		throw ConstraintException("Need to initialize CSR before doing cheapest path");
-	}
-
-	if (context.client_data->csr_list[csr_id]->w.empty()) {
+	if (csr->w.empty()) {
 		bound_function.return_type = LogicalType::DOUBLE;
 	} else {
 		bound_function.return_type = LogicalType::BIGINT;

--- a/extension/sqlpgq/sqlpgq_common.cpp
+++ b/extension/sqlpgq/sqlpgq_common.cpp
@@ -66,17 +66,6 @@ unique_ptr<FunctionData> IterativeLengthFunctionData::IterativeLengthBind(Client
 	}
 
 	int32_t csr_id = ExpressionExecutor::EvaluateScalar(context, *arguments[0]).GetValue<int32_t>();
-	//	if ((uint64_t)csr_id + 1 > context.client_data->csr_list.size()) {
-	//		throw ConstraintException("Invalid ID");
-	//	}
-	//	auto csr_entry = context.client_data->csr_list.find((uint64_t)csr_id);
-	//	if (csr_entry == context.client_data->csr_list.end()) {
-	//		throw ConstraintException("Need to initialize CSR before doing shortest path");
-	//	}
-	//
-	//	if (!(csr_entry->second->initialized_v && csr_entry->second->initialized_e)) {
-	//		throw ConstraintException("Need to initialize CSR before doing shortest path");
-	//	}
 
 	return make_unique<IterativeLengthFunctionData>(context, csr_id);
 }
@@ -92,7 +81,7 @@ CheapestPathLengthFunctionData::CheapestPathLengthBind(ClientContext &context, S
     auto sqlpgq_state_entry = context.registered_state.find("sqlpgq");
     if (sqlpgq_state_entry == context.registered_state.end()) {
         //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
-        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+        throw InternalException("The SQL/PGQ extension has not been loaded");
     }
     auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
 

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_cheapest_path_length.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_cheapest_path_length.cpp
@@ -1,18 +1,12 @@
-#include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/main/client_context.hpp"
-#include "duckdb/main/client_data.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "sqlpgq_common.hpp"
 #include "sqlpgq_functions.hpp"
 
-#include <chrono>
-using namespace std::chrono;
-
 namespace duckdb {
 
 template <typename T, int16_t lane_limit>
-static int16_t InitialiseBellmanFord(ClientContext &context, const DataChunk &args, int64_t input_size,
+static int16_t InitialiseBellmanFord(const DataChunk &args, int64_t input_size,
                                      const UnifiedVectorFormat &vdata_src, const int64_t *src_data, idx_t result_size,
                                      vector<vector<T>> &dists) {
 	dists.resize(input_size, std::vector<T>(lane_limit, std::numeric_limits<T>::max() / 2));
@@ -53,25 +47,25 @@ bool UpdateLanes(vector<vector<T>> &dists, T v, T n, T weight) {
 }
 
 template <typename T, int16_t lane_limit>
-int16_t TemplatedBatchBellmanFord(CheapestPathLengthFunctionData &info, DataChunk &args, int64_t input_size,
-                                  Vector &result, UnifiedVectorFormat vdata_src, int64_t *src_data,
-                                  const UnifiedVectorFormat &vdata_target, int64_t *target_data, int32_t id,
+int16_t TemplatedBatchBellmanFord(CSR* csr, DataChunk &args, int64_t input_size,
+                                  UnifiedVectorFormat vdata_src, int64_t *src_data,
+                                  const UnifiedVectorFormat &vdata_target, int64_t *target_data,
                                   std::vector<T> weight_array, int16_t result_size, T *result_data,
                                   ValidityMask &result_validity) {
 	vector<vector<T>> dists;
 	int16_t curr_batch_size =
-	    InitialiseBellmanFord<T, lane_limit>(info.context, args, input_size, vdata_src, src_data, result_size, dists);
+	    InitialiseBellmanFord<T, lane_limit>(args, input_size, vdata_src, src_data, result_size, dists);
 	bool changed = true;
 	while (changed) {
 		changed = false;
 		//! For every v in the input
 		for (int64_t v = 0; v < input_size; v++) {
 			//! Loop through all the n neighbours of v
-			for (auto index = (int64_t)info.context.client_data->csr_list[id]->v[v];
-			     index < (int64_t)info.context.client_data->csr_list[id]->v[v + 1]; index++) {
+			for (auto index = (int64_t)csr->v[v];
+			     index < (int64_t)csr->v[v + 1]; index++) {
 				//! Get weight of (v,n)
 				changed =
-				    UpdateLanes<T>(dists, v, info.context.client_data->csr_list[id]->e[index], weight_array[index]) |
+				    UpdateLanes<T>(dists, v, csr->e[index], weight_array[index]) |
 				    changed;
 			}
 		}
@@ -96,9 +90,9 @@ int16_t TemplatedBatchBellmanFord(CheapestPathLengthFunctionData &info, DataChun
 }
 
 template <typename T>
-void TemplatedBellmanFord(CheapestPathLengthFunctionData &info, DataChunk &args, int64_t input_size, Vector &result,
+void TemplatedBellmanFord(CSR* csr, DataChunk &args, int64_t input_size, Vector &result,
                           UnifiedVectorFormat vdata_src, int64_t *src_data, const UnifiedVectorFormat &vdata_target,
-                          int64_t *target_data, int32_t id, std::vector<T> weight_array) {
+                          int64_t *target_data, std::vector<T> weight_array) {
 	idx_t result_size = 0;
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto result_data = FlatVector::GetData<T>(result);
@@ -107,44 +101,37 @@ void TemplatedBellmanFord(CheapestPathLengthFunctionData &info, DataChunk &args,
 
 	while (result_size < args.size()) {
 		if ((args.size() - result_size) / 256 >= 1) {
-			result_size += TemplatedBatchBellmanFord<T, 256>(info, args, input_size, result, vdata_src, src_data,
-			                                                 vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 256>(csr, args, input_size,  vdata_src, src_data,
+			                                                 vdata_target, target_data, weight_array, result_size,
 			                                                 result_data, result_validity);
-			;
 		} else if ((args.size() - result_size) / 128 >= 1) {
-			result_size += TemplatedBatchBellmanFord<T, 128>(info, args, input_size, result, vdata_src, src_data,
-			                                                 vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 128>(csr, args, input_size, vdata_src, src_data,
+			                                                 vdata_target, target_data, weight_array, result_size,
 			                                                 result_data, result_validity);
-			;
 		} else if ((args.size() - result_size) / 64 >= 1) {
-			result_size += TemplatedBatchBellmanFord<T, 64>(info, args, input_size, result, vdata_src, src_data,
-			                                                vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 64>(csr, args, input_size,  vdata_src, src_data,
+			                                                vdata_target, target_data,  weight_array, result_size,
 			                                                result_data, result_validity);
-			;
 		} else if ((args.size() - result_size) / 16 >= 1) {
-			result_size += TemplatedBatchBellmanFord<T, 16>(info, args, input_size, result, vdata_src, src_data,
-			                                                vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 16>(csr, args, input_size,  vdata_src, src_data,
+			                                                vdata_target, target_data,  weight_array, result_size,
 			                                                result_data, result_validity);
 		} else if ((args.size() - result_size) / 8 >= 1) {
-			result_size += TemplatedBatchBellmanFord<T, 8>(info, args, input_size, result, vdata_src, src_data,
-			                                               vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 8>(csr, args, input_size, vdata_src, src_data,
+			                                               vdata_target, target_data, weight_array, result_size,
 			                                               result_data, result_validity);
-			;
 		} else if ((args.size() - result_size) / 4 >= 1) {
-			result_size += TemplatedBatchBellmanFord<T, 4>(info, args, input_size, result, vdata_src, src_data,
-			                                               vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 4>(csr, args, input_size, vdata_src, src_data,
+			                                               vdata_target, target_data, weight_array, result_size,
 			                                               result_data, result_validity);
-			;
 		} else if ((args.size() - result_size) / 2 >= 1) {
-			result_size += TemplatedBatchBellmanFord<T, 2>(info, args, input_size, result, vdata_src, src_data,
-			                                               vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 2>(csr, args, input_size, vdata_src, src_data,
+			                                               vdata_target, target_data, weight_array, result_size,
 			                                               result_data, result_validity);
-			;
 		} else {
-			result_size += TemplatedBatchBellmanFord<T, 1>(info, args, input_size, result, vdata_src, src_data,
-			                                               vdata_target, target_data, id, weight_array, result_size,
+			result_size += TemplatedBatchBellmanFord<T, 1>(csr, args, input_size,  vdata_src, src_data,
+			                                               vdata_target, target_data, weight_array, result_size,
 			                                               result_data, result_validity);
-			;
 		}
 	}
 }
@@ -153,7 +140,14 @@ static void CheapestPathLengthFunction(DataChunk &args, ExpressionState &state, 
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (CheapestPathLengthFunctionData &)*func_expr.bind_info;
 	int64_t input_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	D_ASSERT(info.context.client_data->csr_list[info.csr_id]);
+    auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == info.context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
+
+    CSR* csr = sqlpgq_state->GetCSR(info.csr_id);
 	auto &src = args.data[2];
 
 	UnifiedVectorFormat vdata_src, vdata_target;
@@ -164,14 +158,13 @@ static void CheapestPathLengthFunction(DataChunk &args, ExpressionState &state, 
 	auto &target = args.data[3];
 	target.ToUnifiedFormat(args.size(), vdata_target);
 	auto target_data = (int64_t *)vdata_target.data;
-	if (info.context.client_data->csr_list[info.csr_id]->w.empty()) {
-		TemplatedBellmanFord<double_t>(info, args, input_size, result, vdata_src, src_data, vdata_target, target_data,
-		                               info.csr_id, info.context.client_data->csr_list[info.csr_id]->w_double);
+	if (csr->w.empty()) {
+		TemplatedBellmanFord<double_t>(csr, args, input_size, result, vdata_src, src_data, vdata_target, target_data,
+		                               csr->w_double);
 	} else {
-		TemplatedBellmanFord<int64_t>(info, args, input_size, result, vdata_src, src_data, vdata_target, target_data,
-		                              info.csr_id, info.context.client_data->csr_list[info.csr_id]->w);
+		TemplatedBellmanFord<int64_t>(csr, args, input_size, result, vdata_src, src_data, vdata_target, target_data,
+		                              csr->w);
 	}
-	info.context.client_data->csr_list.erase(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetCheapestPathLengthFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_cheapest_path_length.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_cheapest_path_length.cpp
@@ -143,7 +143,7 @@ static void CheapestPathLengthFunction(DataChunk &args, ExpressionState &state, 
     auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
     if (sqlpgq_state_entry == info.context.registered_state.end()) {
         //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
-        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+        throw InternalException("The SQL/PGQ extension has not been loaded");
     }
     auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
 

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_cheapest_path_length.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_cheapest_path_length.cpp
@@ -165,6 +165,7 @@ static void CheapestPathLengthFunction(DataChunk &args, ExpressionState &state, 
 		TemplatedBellmanFord<int64_t>(csr, args, input_size, result, vdata_src, src_data, vdata_target, target_data,
 		                              csr->w);
 	}
+    sqlpgq_state->csr_to_delete.insert(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetCheapestPathLengthFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_csr_creation.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_csr_creation.cpp
@@ -11,11 +11,11 @@
 
 namespace duckdb {
 
-static void CsrInitializeVertex(ClientContext &context, int32_t id, int64_t v_size) {
-	lock_guard<mutex> csr_init_lock(context.client_data->csr_lock);
+static void CsrInitializeVertex(SQLPGQContext &context, int32_t id, int64_t v_size) {
+	lock_guard<mutex> csr_init_lock(context.csr_lock);
 
-	auto csr_entry = context.client_data->csr_list.find(id);
-	if (csr_entry != context.client_data->csr_list.end()) {
+	auto csr_entry = context.csr_list.find(id);
+	if (csr_entry != context.csr_list.end()) {
 		if (csr_entry->second->initialized_v) {
 			return;
 		}
@@ -31,14 +31,7 @@ static void CsrInitializeVertex(ClientContext &context, int32_t id, int64_t v_si
 			csr->v[i] = 0;
 		}
 		csr->initialized_v = true;
-
-		if (csr_entry != context.client_data->csr_list.end()) {
-			context.client_data->csr_list[id] = std::move(csr);
-		} else {
-			//            auto pair = std::pair<int32_t, unique_ptr<CSR>>(id, std::move(csr));
-			context.client_data->csr_list[id] = std::move(csr);
-		}
-
+        context.csr_list[id] = std::move(csr);
 	} catch (std::bad_alloc const &) {
 		throw Exception("Unable to initialise vector of size for csr vertex table representation");
 	}
@@ -46,10 +39,10 @@ static void CsrInitializeVertex(ClientContext &context, int32_t id, int64_t v_si
 	return;
 }
 
-static void CsrInitializeEdge(ClientContext &context, int32_t id, int64_t v_size, int64_t e_size) {
-	const lock_guard<mutex> csr_init_lock(context.client_data->csr_lock);
+static void CsrInitializeEdge(SQLPGQContext &context, int32_t id, int64_t v_size, int64_t e_size) {
+	const lock_guard<mutex> csr_init_lock(context.csr_lock);
 
-	auto csr_entry = context.client_data->csr_list.find(id);
+	auto csr_entry = context.csr_list.find(id);
 	if (csr_entry->second->initialized_e) {
 		return;
 	}
@@ -66,9 +59,9 @@ static void CsrInitializeEdge(ClientContext &context, int32_t id, int64_t v_size
 	return;
 }
 
-static void CsrInitializeWeight(ClientContext &context, int32_t id, int64_t e_size, PhysicalType weight_type) {
-	const lock_guard<mutex> csr_init_lock(context.client_data->csr_lock);
-	auto csr_entry = context.client_data->csr_list.find(id);
+static void CsrInitializeWeight(SQLPGQContext &context, int32_t id, int64_t e_size, PhysicalType weight_type) {
+	const lock_guard<mutex> csr_init_lock(context.csr_lock);
+	auto csr_entry = context.csr_list.find(id);
 
 	if (csr_entry->second->initialized_w) {
 		return;
@@ -93,15 +86,22 @@ static void CreateCsrVertexFunction(DataChunk &args, ExpressionState &state, Vec
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (CSRFunctionData &)*func_expr.bind_info;
 
-	int64_t input_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	auto csr_entry = info.context.client_data->csr_list.find(info.id);
+    auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == info.context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw InternalException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
 
-	if (csr_entry == info.context.client_data->csr_list.end()) {
-		CsrInitializeVertex(info.context, info.id, input_size);
-		csr_entry = info.context.client_data->csr_list.find(info.id);
+	int64_t input_size = args.data[1].GetValue(0).GetValue<int64_t>();
+	auto csr_entry = sqlpgq_state->csr_list.find(info.id);
+
+	if (csr_entry == sqlpgq_state->csr_list.end()) {
+		CsrInitializeVertex(*sqlpgq_state, info.id, input_size);
+		csr_entry = sqlpgq_state->csr_list.find(info.id);
 	} else {
 		if (!csr_entry->second->initialized_v) {
-			CsrInitializeVertex(info.context, info.id, input_size);
+			CsrInitializeVertex(*sqlpgq_state, info.id, input_size);
 		}
 	}
 
@@ -120,12 +120,19 @@ static void CreateCsrEdgeFunction(DataChunk &args, ExpressionState &state, Vecto
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (CSRFunctionData &)*func_expr.bind_info;
 
+    auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == info.context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw InternalException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
+
 	int64_t vertex_size = args.data[1].GetValue(0).GetValue<int64_t>();
 	int64_t edge_size = args.data[2].GetValue(0).GetValue<int64_t>();
 
-	auto csr_entry = info.context.client_data->csr_list.find(info.id);
+	auto csr_entry = sqlpgq_state->csr_list.find(info.id);
 	if (!csr_entry->second->initialized_e) {
-		CsrInitializeEdge(info.context, info.id, vertex_size, edge_size);
+		CsrInitializeEdge(*sqlpgq_state, info.id, vertex_size, edge_size);
 	}
 	if (info.weight_type == LogicalType::SQLNULL) {
 		TernaryExecutor::Execute<int64_t, int64_t, int64_t, int32_t>(
@@ -140,7 +147,7 @@ static void CreateCsrEdgeFunction(DataChunk &args, ExpressionState &state, Vecto
 	}
 	auto weight_type = args.data[6].GetType().InternalType();
 	if (!csr_entry->second->initialized_w) {
-		CsrInitializeWeight(info.context, info.id, edge_size, weight_type);
+		CsrInitializeWeight(*sqlpgq_state, info.id, edge_size, weight_type);
 	}
 	if (weight_type == PhysicalType::INT64) {
 		QuaternaryExecutor::Execute<int64_t, int64_t, int64_t, int64_t, int32_t>(

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength.cpp
@@ -142,6 +142,7 @@ static void IterativeLengthFunction(DataChunk &args, ExpressionState &state, Vec
 			}
 		}
 	}
+    sqlpgq_state->csr_to_delete.insert(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetIterativeLengthFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength.cpp
@@ -31,16 +31,20 @@ static bool IterativeLength(int64_t v_size, int64_t *v, vector<int64_t> &e, vect
 static void IterativeLengthFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (IterativeLengthFunctionData &)*func_expr.bind_info;
+    auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == info.context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw InternalException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
 
-	// get csr info (TODO: do not store in context -- make global map in module that is indexed by id+&context)
+    D_ASSERT(sqlpgq_state->csr_list[info.csr_id]);
 
-	D_ASSERT(info.context.client_data->csr_list[info.csr_id]);
-
-	if ((uint64_t)info.csr_id + 1 > info.context.client_data->csr_list.size()) {
+	if ((uint64_t)info.csr_id + 1 > sqlpgq_state->csr_list.size()) {
 		throw ConstraintException("Invalid ID");
 	}
-	auto csr_entry = info.context.client_data->csr_list.find((uint64_t)info.csr_id);
-	if (csr_entry == info.context.client_data->csr_list.end()) {
+	auto csr_entry = sqlpgq_state->csr_list.find((uint64_t)info.csr_id);
+	if (csr_entry == sqlpgq_state->csr_list.end()) {
 		throw ConstraintException("Need to initialize CSR before doing shortest path");
 	}
 
@@ -48,8 +52,8 @@ static void IterativeLengthFunction(DataChunk &args, ExpressionState &state, Vec
 		throw ConstraintException("Need to initialize CSR before doing shortest path");
 	}
 	int64_t v_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	int64_t *v = (int64_t *)info.context.client_data->csr_list[info.csr_id]->v;
-	vector<int64_t> &e = info.context.client_data->csr_list[info.csr_id]->e;
+	int64_t *v = (int64_t *)sqlpgq_state->csr_list[info.csr_id]->v;
+	vector<int64_t> &e = sqlpgq_state->csr_list[info.csr_id]->e;
 
 	// get src and dst vectors for searches
 	auto &src = args.data[2];
@@ -138,8 +142,6 @@ static void IterativeLengthFunction(DataChunk &args, ExpressionState &state, Vec
 			}
 		}
 	}
-
-	info.context.client_data->csr_list.erase(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetIterativeLengthFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength2.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength2.cpp
@@ -132,6 +132,7 @@ static void IterativeLength2Function(DataChunk &args, ExpressionState &state, Ve
 			}
 		}
 	}
+    sqlpgq_state->csr_to_delete.insert(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetIterativeLength2Function() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength2.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength2.cpp
@@ -32,11 +32,17 @@ static void IterativeLength2Function(DataChunk &args, ExpressionState &state, Ve
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (IterativeLengthFunctionData &)*func_expr.bind_info;
 
-	// get csr info (TODO: do not store in context -- make global map in module that is indexed by id+&context)
-	D_ASSERT(info.context.client_data->csr_list[info.csr_id]);
+    auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == info.context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw InternalException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
+
+    D_ASSERT(sqlpgq_state->csr_list[info.csr_id]);
 	int64_t v_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	int64_t *v = (int64_t *)info.context.client_data->csr_list[info.csr_id]->v;
-	vector<int64_t> &e = info.context.client_data->csr_list[info.csr_id]->e;
+	int64_t *v = (int64_t *)sqlpgq_state->csr_list[info.csr_id]->v;
+	vector<int64_t> &e = sqlpgq_state->csr_list[info.csr_id]->e;
 
 	// get src and dst vectors for searches
 	auto &src = args.data[2];
@@ -126,7 +132,6 @@ static void IterativeLength2Function(DataChunk &args, ExpressionState &state, Ve
 			}
 		}
 	}
-	info.context.client_data->csr_list.erase(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetIterativeLength2Function() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength_bidirectional.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength_bidirectional.cpp
@@ -152,6 +152,7 @@ static void IterativeLengthBidirectionalFunction(DataChunk &args, ExpressionStat
 			}
 		}
 	}
+    sqlpgq_state->csr_to_delete.insert(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetIterativeLengthBidirectionalFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength_bidirectional.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_iterativelength_bidirectional.cpp
@@ -41,11 +41,17 @@ static void IterativeLengthBidirectionalFunction(DataChunk &args, ExpressionStat
 	auto &func_expr = (BoundFunctionExpression &)state.expr;
 	auto &info = (IterativeLengthFunctionData &)*func_expr.bind_info;
 
-	// get csr info (TODO: do not store in context -- make global map in module that is indexed by id+&context)
-	D_ASSERT(info.context.client_data->csr_list[info.csr_id]);
+    auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == info.context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw InternalException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
+
+    D_ASSERT(sqlpgq_state->csr_list[info.csr_id]);
 	int64_t v_size = args.data[1].GetValue(0).GetValue<int64_t>();
-	int64_t *v = (int64_t *)info.context.client_data->csr_list[info.csr_id]->v;
-	vector<int64_t> &e = info.context.client_data->csr_list[info.csr_id]->e;
+	int64_t *v = (int64_t *)sqlpgq_state->csr_list[info.csr_id]->v;
+	vector<int64_t> &e = sqlpgq_state->csr_list[info.csr_id]->e;
 
 	// get src and dst vectors for searches
 	auto &src = args.data[2];
@@ -146,7 +152,6 @@ static void IterativeLengthBidirectionalFunction(DataChunk &args, ExpressionStat
 			}
 		}
 	}
-	info.context.client_data->csr_list.erase(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetIterativeLengthBidirectionalFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_reachability.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_reachability.cpp
@@ -34,7 +34,7 @@ static int16_t InitialiseBfs(idx_t curr_batch, idx_t size, int64_t *src_data, co
 	return curr_batch_size;
 }
 
-static bool BfsWithoutArrayVariant(bool exit_early, int32_t id, int64_t input_size, IterativeLengthFunctionData &info,
+static bool BfsWithoutArrayVariant(bool exit_early, CSR* csr, int64_t input_size,
                                    vector<std::bitset<LANE_LIMIT>> &seen, vector<std::bitset<LANE_LIMIT>> &visit,
                                    vector<std::bitset<LANE_LIMIT>> &visit_next, vector<int64_t> &visit_list) {
 	for (int64_t i = 0; i < input_size; i++) {
@@ -42,10 +42,9 @@ static bool BfsWithoutArrayVariant(bool exit_early, int32_t id, int64_t input_si
 			continue;
 		}
 
-		D_ASSERT(info.context.client_data->csr_list[id]);
-		for (auto index = (int64_t)info.context.client_data->csr_list[id]->v[i];
-		     index < info.context.client_data->csr_list[id]->v[i + 1]; index++) {
-			auto n = info.context.client_data->csr_list[id]->e[index];
+		for (auto index = (int64_t)csr->v[i];
+		     index < csr->v[i + 1]; index++) {
+			auto n = csr->e[index];
 			visit_next[n] = visit_next[n] | visit[i];
 		}
 	}
@@ -66,7 +65,7 @@ static bool BfsWithoutArrayVariant(bool exit_early, int32_t id, int64_t input_si
 	return exit_early;
 }
 
-static bool BfsWithoutArray(bool exit_early, int32_t id, int64_t input_size, ClientContext &context,
+static bool BfsWithoutArray(bool exit_early, CSR* csr, int64_t input_size,
                             vector<std::bitset<LANE_LIMIT>> &seen, vector<std::bitset<LANE_LIMIT>> &visit,
                             vector<std::bitset<LANE_LIMIT>> &visit_next) {
 	for (int64_t i = 0; i < input_size; i++) {
@@ -74,10 +73,9 @@ static bool BfsWithoutArray(bool exit_early, int32_t id, int64_t input_size, Cli
 			continue;
 		}
 
-		D_ASSERT(context.client_data->csr_list[id]);
-		for (auto index = (int64_t)context.client_data->csr_list[id]->v[i];
-		     index < (int64_t)context.client_data->csr_list[id]->v[i + 1]; index++) {
-			auto n = context.client_data->csr_list[id]->e[index];
+		for (auto index = (int64_t)csr->v[i];
+		     index < (int64_t)csr->v[i + 1]; index++) {
+			auto n = csr->e[index];
 			visit_next[n] = visit_next[n] | visit[i];
 		}
 	}
@@ -95,8 +93,8 @@ static bool BfsWithoutArray(bool exit_early, int32_t id, int64_t input_size, Cli
 	return exit_early;
 }
 
-static pair<bool, size_t> BfsTempStateVariant(bool exit_early, int32_t id, int64_t input_size,
-                                              IterativeLengthFunctionData &info, vector<std::bitset<LANE_LIMIT>> &seen,
+static pair<bool, size_t> BfsTempStateVariant(bool exit_early, CSR* csr, int64_t input_size,
+                                              vector<std::bitset<LANE_LIMIT>> &seen,
                                               vector<std::bitset<LANE_LIMIT>> &visit,
                                               vector<std::bitset<LANE_LIMIT>> &visit_next) {
 	size_t num_nodes_to_visit = 0;
@@ -105,10 +103,9 @@ static pair<bool, size_t> BfsTempStateVariant(bool exit_early, int32_t id, int64
 			continue;
 		}
 
-		D_ASSERT(info.context.client_data->csr_list[id]);
-		for (auto index = (int64_t)info.context.client_data->csr_list[id]->v[i];
-		     index < (int64_t)info.context.client_data->csr_list[id]->v[i + 1]; index++) {
-			auto n = info.context.client_data->csr_list[id]->e[index];
+		for (auto index = (int64_t)csr->v[i];
+		     index < (int64_t)csr->v[i + 1]; index++) {
+			auto n = csr->e[index];
 			visit_next[n] = visit_next[n] | visit[i];
 		}
 	}
@@ -129,23 +126,20 @@ static pair<bool, size_t> BfsTempStateVariant(bool exit_early, int32_t id, int64
 	return pair<bool, size_t>(exit_early, num_nodes_to_visit);
 }
 
-static bool BfsWithArrayVariant(bool exit_early, int32_t id, IterativeLengthFunctionData &info,
+static bool BfsWithArrayVariant(bool exit_early, CSR* csr,
                                 vector<std::bitset<LANE_LIMIT>> &seen, vector<std::bitset<LANE_LIMIT>> &visit,
                                 vector<std::bitset<LANE_LIMIT>> &visit_next, vector<int64_t> &visit_list) {
 	unordered_set<int64_t> neighbours_set;
 	for (int64_t i : visit_list) {
-		D_ASSERT(info.context.client_data->csr_list[id]);
-		for (auto index = (int64_t)info.context.client_data->csr_list[id]->v[i];
-		     index < (int64_t)info.context.client_data->csr_list[id]->v[i + 1]; index++) {
-			auto n = info.context.client_data->csr_list[id]->e[index];
+		for (auto index = (int64_t)csr->v[i];
+		     index < (int64_t)csr->v[i + 1]; index++) {
+			auto n = csr->e[index];
 			visit_next[n] = visit_next[n] | visit[i];
 			neighbours_set.insert(n);
 		}
 	}
 	visit_list.clear();
 	for (int64_t i : neighbours_set) {
-		// if (visit_next[i].none())
-		// 	continue;
 		visit_next[i] = visit_next[i] & ~seen[i];
 		seen[i] = seen[i] | visit_next[i];
 		if (exit_early && visit_next[i].any()) {
@@ -192,7 +186,16 @@ static void ReachabilityFunction(DataChunk &args, ExpressionState &state, Vector
 	size_t visit_limit = input_size / VISIT_SIZE_DIVISOR;
 	size_t num_nodes_to_visit = 0;
 	result.SetVectorType(VectorType::FLAT_VECTOR);
+
 	auto result_data = FlatVector::GetData<bool>(result);
+    auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == info.context.registered_state.end()) {
+        //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
+        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
+
+    CSR* csr = sqlpgq_state->GetCSR(info.csr_id);
 
 	while (result_size < args.size()) {
 		vector<std::bitset<LANE_LIMIT>> seen(input_size);
@@ -212,15 +215,15 @@ static void ReachabilityFunction(DataChunk &args, ExpressionState &state, Vector
 				switch (mode) {
 				case 1:
 					exit_early =
-					    BfsWithArrayVariant(exit_early, info.csr_id, info, seen, visit, visit_next, visit_list);
+					    BfsWithArrayVariant(exit_early, csr, seen, visit, visit_next, visit_list);
 					break;
 				case 0:
-					exit_early = BfsWithoutArrayVariant(exit_early, info.csr_id, input_size, info, seen, visit,
+					exit_early = BfsWithoutArrayVariant(exit_early, csr, input_size, seen, visit,
 					                                    visit_next, visit_list);
 					break;
 				case 2: {
 					auto return_pair =
-					    BfsTempStateVariant(exit_early, info.csr_id, input_size, info, seen, visit, visit_next);
+					    BfsTempStateVariant(exit_early, csr, input_size, seen, visit, visit_next);
 					exit_early = return_pair.first;
 					num_nodes_to_visit = return_pair.second;
 					break;
@@ -230,7 +233,7 @@ static void ReachabilityFunction(DataChunk &args, ExpressionState &state, Vector
 				}
 			} else {
 				exit_early =
-				    BfsWithoutArray(exit_early, info.csr_id, input_size, info.context, seen, visit, visit_next);
+				    BfsWithoutArray(exit_early, csr, input_size, seen, visit, visit_next);
 			}
 
 			visit = visit_next;
@@ -255,7 +258,6 @@ static void ReachabilityFunction(DataChunk &args, ExpressionState &state, Vector
 		}
 		result_size = result_size + curr_batch_size;
 	}
-	info.context.client_data->csr_list.erase(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetReachabilityFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_reachability.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_reachability.cpp
@@ -258,6 +258,7 @@ static void ReachabilityFunction(DataChunk &args, ExpressionState &state, Vector
 		}
 		result_size = result_size + curr_batch_size;
 	}
+    sqlpgq_state->csr_to_delete.insert(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetReachabilityFunction() {

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_reachability.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_reachability.cpp
@@ -191,7 +191,7 @@ static void ReachabilityFunction(DataChunk &args, ExpressionState &state, Vector
     auto sqlpgq_state_entry = info.context.registered_state.find("sqlpgq");
     if (sqlpgq_state_entry == info.context.registered_state.end()) {
         //! Wondering how you can get here if the extension wasn't loaded, but leaving this check in anyways
-        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+        throw InternalException("The SQL/PGQ extension has not been loaded");
     }
     auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
 

--- a/extension/sqlpgq/sqlpgq_functions/sqlpgq_shortest_path.cpp
+++ b/extension/sqlpgq/sqlpgq_functions/sqlpgq_shortest_path.cpp
@@ -204,6 +204,7 @@ static void ShortestPathFunction(DataChunk &args, ExpressionState &state, Vector
 			total_len += result_data[search_num].length;
 		}
 	}
+    sqlpgq_state->csr_to_delete.insert(info.csr_id);
 }
 
 CreateScalarFunctionInfo SQLPGQFunctions::GetShortestPathFunction() {

--- a/src/execution/operator/schema/physical_create_property_graph.cpp
+++ b/src/execution/operator/schema/physical_create_property_graph.cpp
@@ -31,12 +31,11 @@ void PhysicalCreatePropertyGraph::GetData(ExecutionContext &context, DataChunk &
 		return;
 	}
 
-	auto &client_data = ClientData::Get(context.client);
 
 	//! During the binder we already check if the property graph exists
     auto sqlpgq_state_entry = context.client.registered_state.find("sqlpgq");
     if (sqlpgq_state_entry == context.client.registered_state.end()) {
-        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+        throw InternalException("The SQL/PGQ extension has not been loaded");
     }
     auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
     sqlpgq_state->InsertPropertyGraph(info->property_graph_name, info->Copy());

--- a/src/execution/operator/schema/physical_create_property_graph.cpp
+++ b/src/execution/operator/schema/physical_create_property_graph.cpp
@@ -30,8 +30,7 @@ void PhysicalCreatePropertyGraph::GetData(ExecutionContext &context, DataChunk &
 	if (state.finished) {
 		return;
 	}
-
-
+    
 	//! During the binder we already check if the property graph exists
     auto sqlpgq_state_entry = context.client.registered_state.find("sqlpgq");
     if (sqlpgq_state_entry == context.client.registered_state.end()) {

--- a/src/execution/operator/schema/physical_create_property_graph.cpp
+++ b/src/execution/operator/schema/physical_create_property_graph.cpp
@@ -38,7 +38,7 @@ void PhysicalCreatePropertyGraph::GetData(ExecutionContext &context, DataChunk &
         throw InternalException("The SQL/PGQ extension has not been loaded");
     }
     auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
-    sqlpgq_state->InsertPropertyGraph(info->property_graph_name, info->Copy());
+    sqlpgq_state->registered_property_graphs[info->property_graph_name] = info->Copy();
 	state.finished = true;
 }
 

--- a/src/execution/operator/schema/physical_create_property_graph.cpp
+++ b/src/execution/operator/schema/physical_create_property_graph.cpp
@@ -2,6 +2,8 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/client_data.hpp"
 
+#include "../../../extension/sqlpgq/include/sqlpgq_common.hpp"
+
 namespace duckdb {
 
 class CreatePropertyGraphSourceState : public GlobalSourceState {
@@ -32,8 +34,12 @@ void PhysicalCreatePropertyGraph::GetData(ExecutionContext &context, DataChunk &
 	auto &client_data = ClientData::Get(context.client);
 
 	//! During the binder we already check if the property graph exists
-	client_data.registered_property_graphs[info->property_graph_name] = info->Copy();
-
+    auto sqlpgq_state_entry = context.client.registered_state.find("sqlpgq");
+    if (sqlpgq_state_entry == context.client.registered_state.end()) {
+        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+    }
+    auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
+    sqlpgq_state->InsertPropertyGraph(info->property_graph_name, info->Copy());
 	state.finished = true;
 }
 

--- a/src/include/duckdb/main/client_data.hpp
+++ b/src/include/duckdb/main/client_data.hpp
@@ -62,12 +62,6 @@ struct ClientData {
 	//! The file search path
 	string file_search_path;
 
-	//! Property graphs that are registered
-	unordered_map<string, unique_ptr<CreateInfo>> registered_property_graphs;
-
-	//! Used to build the CSR data structures required for path-finding queries
-	std::unordered_map<int32_t, unique_ptr<CSR>> csr_list;
-	std::mutex csr_lock;
 
 public:
 	DUCKDB_API static ClientData &Get(ClientContext &context);

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -182,10 +182,14 @@ static void CheckPropertyGraphTableColumns(shared_ptr<PropertyGraphTable> &pg_ta
 void Binder::BindCreatePropertyGraphInfo(CreatePropertyGraphInfo &info) {
     auto sqlpgq_state_entry = context.registered_state.find("sqlpgq");
     if (sqlpgq_state_entry == context.registered_state.end()) {
-        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+        throw InternalException("The SQL/PGQ extension has not been loaded");
     }
     auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
     auto pg_table = sqlpgq_state->GetPropertyGraph(info.property_graph_name);
+
+    if (pg_table == nullptr) {
+        throw InternalException("Property graph table %s not found", info.property_graph_name);
+    }
 
 	auto &catalog = Catalog::GetCatalog(context, info.catalog);
 

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -192,7 +192,7 @@ void Binder::BindCreatePropertyGraphInfo(CreatePropertyGraphInfo &info) {
     auto pg_table = sqlpgq_state->registered_property_graphs.find(info.property_graph_name);
 
     if (pg_table != sqlpgq_state->registered_property_graphs.end()) {
-        throw InternalException("Property graph table with name %s already exists", info.property_graph_name);
+        throw ConstraintException("Property graph table with name %s already exists", info.property_graph_name);
     }
 
 	auto &catalog = Catalog::GetCatalog(context, info.catalog);

--- a/src/planner/binder/tableref/bind_matchref.cpp
+++ b/src/planner/binder/tableref/bind_matchref.cpp
@@ -131,7 +131,7 @@ unique_ptr<BoundTableRef> Binder::Bind(MatchRef &ref) {
 
     auto sqlpgq_state_entry = context.registered_state.find("sqlpgq");
     if (sqlpgq_state_entry == context.registered_state.end()) {
-        throw MissingExtensionException("The SQL/PGQ extension has not been loaded");
+        throw InternalException("The SQL/PGQ extension has not been loaded");
     }
     auto sqlpgq_state = reinterpret_cast<SQLPGQContext *>(sqlpgq_state_entry->second.get());
 	auto pg_table = sqlpgq_state->GetPropertyGraph(ref.pg_name);

--- a/test/sql/sqlpgq/basic_match.test
+++ b/test/sql/sqlpgq/basic_match.test
@@ -107,16 +107,6 @@ Daniel	Tavneet
 Daniel	Gabor
 Daniel	Peter
 
-#query II
-#SELECT study.a_name, study.b_name
-#FROM (SELECT a.name as a_name, b.name as b_name
-#       FROM Student a, Know k, Student b
-#       WHERE (a.id = k.src and b.id = k.dst) or (a.id = k.dst and b.id = k.src)
-#       )
-#       study
-#----
-#Daniel	Gabor
-
 query II
 SELECT study.a_name, study.b_name
 FROM GRAPH_TABLE (pg,

--- a/test/sql/sqlpgq/basic_match.test
+++ b/test/sql/sqlpgq/basic_match.test
@@ -4,6 +4,8 @@
 statement ok
 pragma enable_verification
 
+require sqlpgq
+
 statement ok
 CREATE TABLE Student(id BIGINT, name VARCHAR);
 

--- a/test/sql/sqlpgq/basic_match.test
+++ b/test/sql/sqlpgq/basic_match.test
@@ -198,3 +198,35 @@ Gabor	Peter	Daniel
 Peter	Daniel	Gabor
 Peter	Daniel	Tavneet
 
+
+statement ok
+CREATE PROPERTY GRAPH pg2
+VERTEX TABLES (
+    Student PROPERTIES ( id, name ) LABEL Person,
+    School LABEL SCHOOL
+    )
+EDGE TABLES (
+    know    SOURCE KEY ( src ) REFERENCES Student ( id )
+            DESTINATION KEY ( dst ) REFERENCES Student ( id )
+            LABEL Knows,
+    studyAt SOURCE KEY ( personId ) REFERENCES Student ( id )
+            DESTINATION KEY ( SchoolId ) REFERENCES School ( id )
+            LABEL StudyAt
+    );
+
+query III
+SELECT study.a_name, study.b_name, study.c_name
+FROM GRAPH_TABLE (pg2,
+    MATCH
+    (a:Person)-[k:Knows]->(b:Person)-[k2:Knows]->(c:Person)-[k3:Knows]->(a:Person)
+    COLUMNS (a.name as a_name, b.name as b_name, c.name as c_name)
+    ) study;
+----
+Daniel	Tavneet	Peter
+Daniel	Gabor	Peter
+Tavneet	Peter	Daniel
+Gabor	Peter	Daniel
+Peter	Daniel	Gabor
+Peter	Daniel	Tavneet
+
+

--- a/test/sql/sqlpgq/create_property_graph.test
+++ b/test/sql/sqlpgq/create_property_graph.test
@@ -33,6 +33,7 @@ EDGE TABLES (
     )
 
 # Error as property graph pg already exists
+
 statement error
 CREATE PROPERTY GRAPH pg
 VERTEX TABLES (


### PR DESCRIPTION
Moves the CSR list and registered property graph from the ClientContext to a SQLPGQContext. The SQLPGQContext is created when the user registers the first property graph. 
Additionally, at the end of every query, we remove all CSRs that have been created. Whereas before the CSR was deleted after every path-finding