### PR TITLE
Add a suggestion to the error for label not found

### DIFF
--- a/src/include/duckdb/parser/parsed_data/create_property_graph_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_property_graph_info.hpp
@@ -83,7 +83,7 @@ public:
 	        }
 	    	if (error_not_found) {
 	            throw Exception(ExceptionType::INVALID,
-	                            "Exact table '" + table_name + "' found, but it is not a " +
+	                            "Exact label '" + table_name + "' found, but it is not a " +
 	                            (is_vertex_table ? "vertex" : "edge") + " table.");
 	        }
 	        return nullptr;
@@ -101,7 +101,7 @@ public:
 	            continue;
 	        }
 	    	if  (pg_table->table_name == table_name) {
-	    		throw Exception(ExceptionType::INVALID, "Table " + table_name + " found in the property graph, but does not have the correct label. Did you mean the label '" + pg_table->main_label + "' instead?");
+	    		throw Exception(ExceptionType::INVALID, "Table '" + table_name + "' found in the property graph, but does not have the correct label. Did you mean the label '" + pg_table->main_label + "' instead?");
 	    	}
 
 	        // Use int64_t for the distance calculations


### PR DESCRIPTION
Related to https://github.com/cwida/duckpgq-extension/issues/148
PR in DuckPGQ: 

Improves the error message if a label was not found for any of the graph functions. Give a suggestion of a label that is closest to whatever the input was. 